### PR TITLE
Updates getters for the external-db and ports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "architect-plugin-dynamodb-local-streams",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "architect-plugin-dynamodb-local-streams",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "@architect/functions": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nasa-gcn/architect-plugin-dynamodb-local-streams",
   "description": "Architect plugin for Local DynamoDB Streams",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "repository": {
     "type": "git",
     "url": "github:nasa-gcn/architect-plugin-dynamodb-local-streams"


### PR DESCRIPTION
Uses the same functions as the ddb local plugin. 

In a later update, the functionality here may get wrapped into the other plugin. But I will cross that bridge when I come to it.